### PR TITLE
Fixes #1, preparePayment error due to jsonschema validation update.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "casinocoin-libjs",
-    "version": "1.0.2",
+    "version": "1.0.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -5104,9 +5104,9 @@
             "dev": true
         },
         "jsonschema": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.0.tgz",
-            "integrity": "sha512-XDJApzBauMg0TinJNP4iVcJl99PQ4JbWKK7nwzpOIkAOVveDKgh/2xm41T3x7Spu4PWMhnnQpNJmUSIUgl6sKg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+            "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
         },
         "jsprim": {
             "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "babel-runtime": "^6.3.19",
         "bignumber.js": "^2.0.3",
         "https-proxy-agent": "^1.0.0",
-        "jsonschema": "^1.1.1",
+        "jsonschema": "1.2.2",
         "lodash": "^3.1.0",
         "casinocoin-libjs-address-codec": "^1.0.0",
         "casinocoin-libjs-binary-codec": "^1.0.3",


### PR DESCRIPTION
Locks jsonschema at 1.2.2 for now.

see ripple issue #80