### PR TITLE
update getServerInfo to reflect server_info command in casinocoind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "casinocoin-libjs",
-    "version": "1.0.2",
+    "version": "1.0.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -5104,9 +5104,9 @@
             "dev": true
         },
         "jsonschema": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.0.tgz",
-            "integrity": "sha512-XDJApzBauMg0TinJNP4iVcJl99PQ4JbWKK7nwzpOIkAOVveDKgh/2xm41T3x7Spu4PWMhnnQpNJmUSIUgl6sKg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+            "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
         },
         "jsprim": {
             "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "babel-runtime": "^6.3.19",
         "bignumber.js": "^2.0.3",
         "https-proxy-agent": "^1.0.0",
-        "jsonschema": "^1.1.1",
+        "jsonschema": "1.2.2",
         "lodash": "^3.1.0",
         "casinocoin-libjs-address-codec": "^1.0.0",
         "casinocoin-libjs-binary-codec": "^1.0.3",

--- a/src/common/serverinfo.js
+++ b/src/common/serverinfo.js
@@ -40,14 +40,14 @@ function renameKeys(object, mapping) {
 }
 
 function getServerInfo(connection: Connection): Promise < GetServerInfoResponse > {
-    return connection.request({ command: 'server_state' }).then(response => {
-        const info = convertKeysFromSnakeCaseToCamelCase(response.state)
-        // renameKeys(info, { hostid: 'hostID' })
+    return connection.request({ command: 'server_info' }).then(response => {
+        const info = convertKeysFromSnakeCaseToCamelCase(response.info)
+        renameKeys(info, { hostid: 'hostID' })
         if (info.validatedLedger) {
             renameKeys(info.validatedLedger, {
-                baseFee: 'baseFeeCSC',
-                reserveBase: 'reserveBaseCSC',
-                reserveInc: 'reserveIncrementCSC',
+                baseFeeCsc: 'baseFeeCSC',
+                reserveBaseCsc: 'reserveBaseCSC',
+                reserveIncCsc: 'reserveIncrementCSC',
                 seq: 'ledgerVersion'
             })
             info.validatedLedger.baseFeeCSC = dropsToCsc(info.validatedLedger.baseFeeCSC.toString())


### PR DESCRIPTION
I came across this when reviewing the docs and the quickstart tutorial.

I noticed quite a few of the fields were missing and found that when server_state is called it returns different fields.  Since the method name lines up with the method name, I thought this might have just been an error. 

If server_state results are desired, it would make more sense to rename the method accordingly.  Just my 2 cents